### PR TITLE
Replace countmerge with a small awk script, removing Rust dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ You will need three programming environments installed:
 
 - Python 3.4 or later
 - Haskell, installed with `haskell-stack`, used to compile and run `wikiparsec`
-- The Rust programming language, version 1.14 or later, installed with `rustup`,
-  used to compile `countmerge`
 
 You also need certain tools to be available:
 
 - The C library for `mecab` (apt install libmecab-dev)
 - The ICU Unicode libraries (apt install libicu-dev)
 - The JSON processor `jq` (apt install jq)
-- countmerge (https://github.com/rspeer/countmerge)
+- The XML processor `xml2` (apt install xml2)
 - wikiparsec (https://github.com/LuminosoInsight/wikiparsec)
 
 
@@ -38,20 +36,12 @@ Some steps here probably need to be filled in better.
 apt install python3-dev haskell-stack mecab-dev libicu-dev jq
 ```
 
-- Install Rust: https://www.rust-lang.org/en-US/install.html
-
 - Clone, build, and install `wikiparsec`:
 
 ```sh
 git clone https://github.com/LuminosoInsight/wikiparsec
 cd wikiparsec
 stack install
-```
-
-- Install `countmerge`:
-
-```sh
-cargo install countmerge
 ```
 
 - Finally, return to this directory and install `exquisite-corpus` itself,

--- a/Snakefile
+++ b/Snakefile
@@ -492,7 +492,7 @@ rule extract_google_1grams:
     shell:
         # Lowercase the terms, remove part-of-speech tags such as _NOUN, and
         # run the result through the 'countmerge' utility
-        r"zcat {input} | sed -n -e 's/\([^_	]\+\)\(_[A-Z]\+\)/\L\1/p' | countmerge > {output}"
+        r"zcat {input} | sed -n -e 's/\([^_	]\+\)\(_[A-Z]\+\)/\L\1/p' | awk -f scripts/countmerge.awk > {output}"
 
 rule extract_reddit:
     input:
@@ -611,7 +611,7 @@ rule transform_2grams:
     output:
         "data/messy-counts/google-ngrams/2grams-{lang}-{prefix}.txt"
     shell:
-        r"zcat {input} | sed -re 's/_[A-Z.]*//g' | tr A-Z a-z | countmerge > {output}"
+        r"zcat {input} | sed -re 's/_[A-Z.]*//g' | tr A-Z a-z | awk -f scripts/countmerge.awk > {output}"
 
 rule transform_3grams:
     input:
@@ -619,7 +619,7 @@ rule transform_3grams:
     output:
         "data/messy-counts/google-ngrams/3grams-{lang}-{prefix}.txt"
     shell:
-        r"zcat {input} | sed -re 's/_[A-Z.]*//g' | tr A-Z a-z | countmerge > {output}"
+        r"zcat {input} | sed -re 's/_[A-Z.]*//g' | tr A-Z a-z | awk -f scripts/countmerge.awk > {output}"
 
 rule concat_2grams:
     input:
@@ -627,7 +627,7 @@ rule concat_2grams:
     output:
         "data/messy-counts/google-ngrams/2grams-combined-en.txt.gz"
     shell:
-        "grep -Eh '[0-9]{{3,}}$' {input} | LANG=C sort | countmerge | gzip -c > {output}"
+        "grep -Eh '[0-9]{{3,}}$' {input} | LANG=C sort | awk -f scripts/countmerge.awk | gzip -c > {output}"
 
 rule concat_3grams:
     input:
@@ -635,7 +635,7 @@ rule concat_3grams:
     output:
         "data/messy-counts/google-ngrams/3grams-combined-en.txt.gz"
     shell:
-        "grep -Eh '[0-9]{{3,}}$' {input} | LANG=C sort | countmerge | gzip -c > {output}"
+        "grep -Eh '[0-9]{{3,}}$' {input} | LANG=C sort | awk -f scripts/countmerge.awk | gzip -c > {output}"
 
 
 # Tokenizing

--- a/scripts/countmerge.awk
+++ b/scripts/countmerge.awk
@@ -1,0 +1,38 @@
+# Given a tab-separated, sorted file where each line is a key and a count,
+# merge adjacent lines with the same key by adding their counts.
+
+BEGIN {
+    # Input and output are separated by tabs only
+    FS = "\t"
+    OFS = "\t"
+
+    # Initialize the current count.
+    # We use the empty string as a sentinel value, indicating that we haven't
+    # seen a key yet. We won't output a total for the empty string.
+    key = ""
+    count = 0
+}
+
+# This block has no condition, so it runs on every line.
+{
+    if ($1 == key) {
+        # The key matches the current key, so add to the count.
+        count += $2
+    } else {
+        # This is a new key. First, output the old key and its count.
+        if (key != "") {
+            print key, count
+        }
+        # Now set the key to the new key, with the count we've just seen.
+        # Concatenate the key with the empty string to force it to have string
+        # type; otherwise, for example, "0" and "00" would be considered the
+        # same key.
+        key = $1""
+        count = $2
+    }
+}
+
+END {
+    # Output the final key and its count.
+    print key, count
+}


### PR DESCRIPTION
I tested rebuilding some files to make sure it gives the same counts. In particular, I re-ran Google Books 1-grams in Italian and Simplified Chinese, and the totals came out the same.

Awk is actually a pretty nice language as long as you're not trying to fit the script on one line!