### PR TITLE
Fix chicken-and-egg bug with wordfreq in Chinese

### DIFF
--- a/exquisite_corpus/count.py
+++ b/exquisite_corpus/count.py
@@ -49,7 +49,7 @@ def recount_messy(infile, outfile, language):
         if line and not line.startswith('__total__'):
             text, strcount = line.split('\t', 1)
             count = int(strcount)
-            for token in tokenize(text, language):
+            for token in tokenize(text, language, external_wordlist=True):
                 counts[token] += count
                 total += count
 


### PR DESCRIPTION
We added the `external_wordlist=True` option to wordfreq to avoid a
chicken-and-egg cycle where XC would build a Chinese wordlist, which got
incorporated into wordfreq, which changed the way XC tokenized Chinese,
causing inconsistent results.

I forgot to use this option in `recount_messy` until now.