### PR TITLE
Reorganize when 'lossy_tokenize' happens to apply it consistently

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -872,7 +872,7 @@ rule count_tokens:
     input:
         "data/tokenized/{source}/{lang}.txt"
     output:
-        "data/counts/{source}/{lang}.txt"
+        "data/messy-counts/{source}/{lang}.txt"
     shell:
         "xc count {input} {output}"
 

--- a/exquisite_corpus/count.py
+++ b/exquisite_corpus/count.py
@@ -1,9 +1,7 @@
 from collections import Counter
 from ftfy.fixes import uncurl_quotes
-from wordfreq.tokens import tokenize
+from wordfreq.tokens import lossy_tokenize, TOKEN_RE
 import regex
-
-PUNCT_RE = regex.compile(r'\p{punct}')
 
 BAD_TOKENS = {
     '', '\N{PILCROW SIGN}', '\ufffc', '\ufffd',
@@ -49,14 +47,14 @@ def recount_messy(infile, outfile, language):
         if line and not line.startswith('__total__'):
             text, strcount = line.split('\t', 1)
             count = int(strcount)
-            for token in tokenize(text, language, external_wordlist=True):
+            for token in lossy_tokenize(text, language, external_wordlist=True):
                 counts[token] += count
                 total += count
 
     # Write the counted tokens to outfile
     print('__total__\t{}'.format(total), file=outfile)
     for token, count in counts.most_common():
-        if not PUNCT_RE.match(token):
+        if TOKEN_RE.match(token):
             print('{}\t{}'.format(token, count), file=outfile)
 
 

--- a/exquisite_corpus/tokens.py
+++ b/exquisite_corpus/tokens.py
@@ -1,4 +1,4 @@
-from wordfreq.tokens import tokenize, lossy_tokenize
+from wordfreq.tokens import tokenize
 from ftfy import fix_text
 from ftfy.fixes import unescape_html, fix_surrogates
 import regex
@@ -77,7 +77,7 @@ def tokenize_file(infile, outfile, language, check_language=False, punctuation=F
         else:
             # Run only specific quick fixes from ftfy
             line = fix_surrogates(unescape_html(line.rstrip()))
-        tokens = lossy_tokenize(line, language, include_punctuation=punctuation, external_wordlist=True)
+        tokens = tokenize(line, language, include_punctuation=punctuation, external_wordlist=True)
         checked_lang = None
         if check_language:
             checked_lang, _confident = cld2_detect_language(line.rstrip())


### PR DESCRIPTION
This sets up a consistent flow to avoid sources that have gone through
different tokenization steps:

- `xc count` uses `tokenize`, and takes files from tokenized to messy-counts
- `xc recount` uses `lossy_tokenize`, and takes files from messy-counts to counts
- All sources go through `xc recount` eventually

Additionally, when recounting, instead of using our own PUNCT_RE to try to exclude non-word tokens, we use TOKEN_RE from wordfreq.

I didn't take the time to rebase this branch to exclude the other PRs. #4 and #5 should be merged first, and then the set of changes here will make more sense.