### PR TITLE
Fixing a build bug and getting cleaner data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -493,7 +493,7 @@ rule download_paracrawl:
     output:
         "data/downloaded/paracrawl/{lang1}_{lang2}.tmx.gz"
     shell:
-        "curl -lf 'https://s3.amazonaws.com/web-language-models/paracrawl/release1.2/paracrawl-release1.2.{wildcards.lang1}-{wildcards.lang2}.withstats.filtered-bicleaner.tmx.gz' -o {output}"
+        "curl -lf 'https://s3.amazonaws.com/web-language-models/paracrawl/release1.2/paracrawl-release1.2.{wildcards.lang1}-{wildcards.lang2}.withstats.filtered-zipporah.tmx.gz' -o {output}"
 
 
 # Handling downloaded data

--- a/exquisite_corpus/count.py
+++ b/exquisite_corpus/count.py
@@ -31,7 +31,7 @@ def count_tokenized(infile, outfile):
     # Write the counted tokens to outfile
     print('__total__\t{}'.format(total), file=outfile)
     for token, adjcount in adjusted_counts.most_common():
-        if not PUNCT_RE.match(token):
+        if TOKEN_RE.match(token):
             print('{}\t{}'.format(token, adjcount + 1), file=outfile)
 
 


### PR DESCRIPTION
The effects of this PR are:

* Finish the switch from using a bespoke `PUNCT_RE` to wordfreq's `TOKEN_RE`, so that our assessment of what counts as a word is consistent with wordfreq. This was left half-finished in a previous PR, causing a build bug.

* We can incorporate ParaCrawl with a somewhat better-filtered data set. (See the commit message for this commit for more details.)