### PR TITLE
More parallel texts

### DIFF
--- a/exquisite_corpus/count.py
+++ b/exquisite_corpus/count.py
@@ -31,7 +31,7 @@ def count_tokenized(infile, outfile):
     # Write the counted tokens to outfile
     print('__total__\t{}'.format(total), file=outfile)
     for token, adjcount in adjusted_counts.most_common():
-        if not PUNCT_RE.match(token):
+        if TOKEN_RE.match(token):
             print('{}\t{}'.format(token, adjcount + 1), file=outfile)
 
 

--- a/scripts/tmx-language-tagger.awk
+++ b/scripts/tmx-language-tagger.awk
@@ -6,7 +6,22 @@
 # onto the same line by piping the result to the shell command 'paste - -'.
 
 # Output from this script will be tab-separated
-BEGIN { OFS="\t" }
+BEGIN {
+    OFS="\t"
+    valid = 1
+}
+
+# If we see "prop=0.0", that's a value from either Zipporah or Bicleaner
+# telling us that this entry is garbage.
+/prop=0\.0$/ {
+    valid = 0
+}
+
+# At the end of each text unit, reset our assumption that the next example
+# will be valid, until we're told otherwise.
+/\/tu$/ {
+    valid = 1
+}
 
 # The idiom that follows allows matching something on one line, and processing
 # both that line and the following line.
@@ -16,17 +31,19 @@ BEGIN { OFS="\t" }
 
 # Match a <tuv> node with an "@xml:lang" attribute, as output by the xml2 tool
 /tuv\/@xml:lang=/ {
-    # Extract the language tag, by splitting on "@xml:lang=" and storing the part afterward
-    split($0, langParts, "@xml:lang=")
-    lang = langParts[2]
-    
-    # Go to the next line
-    getline
+    if (valid == 1) {
+        # Extract the language tag, by splitting on "@xml:lang=" and storing the part afterward
+        split($0, langParts, "@xml:lang=")
+        lang = langParts[2]
 
-    # Extract the value of the "seg" attribute, which is the text
-    split($0, textParts, "tu/tuv/seg=")
-    text = textParts[2]
+        # Go to the next line
+        getline
 
-    print lang, text
+        # Extract the value of the "seg" attribute, which is the text
+        split($0, textParts, "tu/tuv/seg=")
+        text = textParts[2]
+
+        print lang, text
+    }
 }
 


### PR DESCRIPTION
- Use Tatoeba (a corpus of pedagogical sentences) and Europarl as additional parallel-text inputs
- Learn parallel text in any language that is in at least one of OpenSubtitles2018 or Paracrawl
- Re-do the workflow for OPUS corpora, so that they can all be handled the same way, from downloading to parallel text handling
- When getting text from Paracrawl TMX files, filter out the entries that get a rating of 0.0 from either filter