### PR TITLE
Get more sources of parallel text, and process them with subword-nmt

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -935,7 +935,7 @@ rule split_train_valid:
         train_file, valid_file = output
         shell(
             "head -n 100000 {input} > {valid_file} && "
-            "tail -n +100001 {output} > {train_file}"
+            "tail -n +100001 {input} > {train_file}"
         )
 
 
@@ -945,7 +945,7 @@ rule rejoin_training_data:
         "data/parallel/bpe/{lang1}_{lang2}.{lang2}.{mode}.txt"
     output:
         "data/parallel/training/{lang1}_{lang2}.{mode}.txt"
-    run:
+    shell:
         "paste {input} > {output}"
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -270,8 +270,7 @@ PARALLEL_LANGUAGE_PAIRS = [
 
 def map_opus_language(dataset, lang):
     if dataset.startswith('opus/'):
-        print("Wildcard matched incorrectly; the 'opus/' directory should not be included in the match.")
-        raise ValueError(dataset)
+        raise ValueError("Wildcard matched incorrectly; the 'opus/' directory should not be included in the match.")
     if dataset == 'Tatoeba':
         # Tatoeba language codes are sometimes more specific than we want.
         mapping = {
@@ -302,7 +301,6 @@ def map_opus_language(dataset, lang):
             'pt-PT': 'pt'
         }
     else:
-        print("Unknown OPUS dataset: %r" % dataset)
         raise ValueError("Unknown OPUS dataset: %r" % dataset)
     return mapping.get(lang, lang)
 
@@ -366,7 +364,6 @@ def multisource_counts_to_merge(multisource, lang):
         for source in MERGED_SOURCES[multisource]
         if lang in SOURCE_LANGUAGES[source]
     ]
-    print("merging {} to make {}/{}".format(result, multisource, lang))
     return result
 
 

--- a/exquisite_corpus/count.py
+++ b/exquisite_corpus/count.py
@@ -31,7 +31,7 @@ def count_tokenized(infile, outfile):
     # Write the counted tokens to outfile
     print('__total__\t{}'.format(total), file=outfile)
     for token, adjcount in adjusted_counts.most_common():
-        if not PUNCT_RE.match(token):
+        if TOKEN_RE.match(token):
             print('{}\t{}'.format(token, adjcount + 1), file=outfile)
 
 

--- a/scripts/tmx-language-tagger.awk
+++ b/scripts/tmx-language-tagger.awk
@@ -6,7 +6,22 @@
 # onto the same line by piping the result to the shell command 'paste - -'.
 
 # Output from this script will be tab-separated
-BEGIN { OFS="\t" }
+BEGIN {
+    OFS="\t"
+    valid = 1
+}
+
+# If we see "prop=0.0", that's a value from either Zipporah or Bicleaner
+# telling us that this entry is garbage.
+/prop=0\.0$/ {
+    valid = 0
+}
+
+# At the end of each text unit, reset our assumption that the next example
+# will be valid, until we're told otherwise.
+/\/tu$/ {
+    valid = 1
+}
 
 # The idiom that follows allows matching something on one line, and processing
 # both that line and the following line.
@@ -16,17 +31,19 @@ BEGIN { OFS="\t" }
 
 # Match a <tuv> node with an "@xml:lang" attribute, as output by the xml2 tool
 /tuv\/@xml:lang=/ {
-    # Extract the language tag, by splitting on "@xml:lang=" and storing the part afterward
-    split($0, langParts, "@xml:lang=")
-    lang = langParts[2]
-    
-    # Go to the next line
-    getline
+    if (valid == 1) {
+        # Extract the language tag, by splitting on "@xml:lang=" and storing the part afterward
+        split($0, langParts, "@xml:lang=")
+        lang = langParts[2]
 
-    # Extract the value of the "seg" attribute, which is the text
-    split($0, textParts, "tu/tuv/seg=")
-    text = textParts[2]
+        # Go to the next line
+        getline
 
-    print lang, text
+        # Extract the value of the "seg" attribute, which is the text
+        split($0, textParts, "tu/tuv/seg=")
+        text = textParts[2]
+
+        print lang, text
+    }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ setup(
     description="Download and process many gigabytes of natural language data, assembled from various corpora.",
     packages=['exquisite_corpus'],
     include_package_data=True,
-    install_requires=['snakemake', 'wordfreq[jieba,mecab] >= 2', 'click', 'regex == 2018.02.21', 'pycld2', 'msgpack-python', 'ordered-set', 'ftfy'],
+    install_requires=[
+        'snakemake', 'wordfreq[jieba,mecab] >= 2', 'click',
+        'regex == 2018.02.21', 'pycld2', 'msgpack-python', 'ordered-set',
+        'ftfy', 'subword-nmt'
+    ],
     zip_safe=False,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This pull request is like #8 but deals with some of its implicit bugs, like the fact that different sources of parallel text sort their languages in a different order.

It also goes a few steps farther, running the text through the `subword-nmt` utilities, which do things like learning a vocabulary and applying BPE to prepare the text for something like fairseq.