### PR TITLE
Use updated Reddit data from Pushshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,12 @@ python setup.py develop
 ## Getting data
 
 Most of the data in Exquisite Corpus will be downloaded from places where it
-can be found on the Web. However, some inputs must be obtained separately.
+can be found on the Web. However, one input must be downloaded separately:
+Twitter data cannot be distributed due to the Twitter API's terms of use.
 
-A corpus of Reddit comments from 2007-2015 can be obtained over BitTorrent [1]:
-
-[1]: https://www.reddit.com/r/datasets/comments/3bxlg7/i_have_every_publicly_available_reddit_comment/
-
-Extract it into `data/raw/reddit`, so that there are directories named `data/raw/reddit/2007` and so on.
-
-Twitter data cannot be distributed due to the Twitter API's terms of use. If
-you have a collection of tweets, put their text in `data/raw/twitter-2015.txt`,
-one tweet per line. Or just put an empty file there.
+If you have a collection of tweets, put their text in
+`data/raw/twitter-2015.txt`, one tweet per line. Or just put an empty file
+there.
 
 
 ## Building

--- a/Snakefile
+++ b/Snakefile
@@ -195,12 +195,12 @@ GOOGLE_3GRAM_SHARDS = [
     if _c1 + _c2 not in {'qg', 'qz', 'xg', 'xq', 'zq'}
 ]
 
-# We have Reddit data that's sharded by month, from 2007-10 to 2015-05.
+# We have Reddit data that's sharded by month, from 2007-10 to 2017-11.
 
 REDDIT_SHARDS = ['{:04d}-{:02d}'.format(y, m) for (y, m) in (
     [(2007, month) for month in range(10, 12 + 1)] +
-    [(year, month) for year in range(2008, 2015) for month in range(1, 12 + 1)] +
-    [(2015, month) for month in range(1, 5 + 1)]
+    [(year, month) for year in range(2008, 2017) for month in range(1, 12 + 1)] +
+    [(2017, month) for month in range(1, 11 + 1)]
 )]
 
 # SNAP's Amazon data is sharded by product department.

--- a/Snakefile
+++ b/Snakefile
@@ -456,6 +456,17 @@ rule download_opus_monolingual:
         source_lang = map_opus_language(dataset, wildcards.lang)
         shell("curl -Lf 'http://opus.nlpl.eu/download.php?f={dataset}/mono/{dataset}.raw.{source_lang}.gz' -o {output}")
 
+
+rule download_reddit:
+    output:
+        "data/downloaded/reddit/{year}-{month}.bz2"
+    resources:
+        download=1, opusdownload=1
+    priority: 0
+    shell:
+        "curl -Lf 'https://files.pushshift.io/reddit/comments/RC_{wildcards.year}-{wildcards.month}.bz2' -o {output}"
+
+
 rule download_opus_parallel:
     output:
         "data/downloaded/opus/{dataset}.{lang1}_{lang2}.zip"
@@ -594,7 +605,7 @@ rule extract_google_1grams:
 
 rule extract_reddit:
     input:
-        "data/raw/reddit/{year}/RC_{year}-{month}.bz2"
+        "data/downloaded/reddit/{year}-{month}.bz2"
     output:
         "data/extracted/reddit/{year}-{month}.txt.gz"
     shell:

--- a/exquisite_corpus/tokens.py
+++ b/exquisite_corpus/tokens.py
@@ -132,7 +132,7 @@ def tokenize_by_language(in_file, out_dir, mode='twitter'):
     }
     try:
         for line in in_file:
-            text = unescape_html(line.rstrip())
+            text = fix_surrogates(unescape_html(line.rstrip()))
             if mode == 'twitter':
                 text = TWITTER_HANDLE_RE.sub('', text)
                 text = TCO_RE.sub('', text)


### PR DESCRIPTION
A loose end from weeks ago, when I thought I was going to need to run fastText on as much Reddit text as possible.

This update downloads the Reddit data from the place where it now lives (pushshift.io) instead of expecting you to somehow BitTorrent it into the `data/raw/` directory (the torrent has not been reliably available for years). It also adds data up through November 2017.