### PR TITLE
Fix names of contents of OPUS OpenSubtitles zip files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -620,14 +620,20 @@ rule extract_opus_parallel:
         # order.
 
         dataset = wildcards.dataset
+        if dataset == 'OpenSubtitles2018':
+            # OPUS renamed the contents of their zip files from
+            # 'OpenSubtitles2018' to 'OpenSubtitles'.
+            zip_dataset = 'OpenSubtitles'
+        else:
+            zip_dataset = dataset
         code1 = map_opus_language(dataset, wildcards.lang1)
         code2 = map_opus_language(dataset, wildcards.lang2)
         codeA, codeB = sorted([code1, code2])
-        zip_output1 = "data/extracted/opus/{dataset}.{codeA}-{codeB}.{code1}".format(
-            code1=code1, code2=code2, codeA=codeA, codeB=codeB, dataset=dataset
+        zip_output1 = "data/extracted/opus/{zip_dataset}.{codeA}-{codeB}.{code1}".format(
+            code1=code1, code2=code2, codeA=codeA, codeB=codeB, zip_dataset=zip_dataset
         )
-        zip_output2 = "data/extracted/opus/{dataset}.{codeA}-{codeB}.{code2}".format(
-            code1=code1, code2=code2, codeA=codeA, codeB=codeB, dataset=dataset
+        zip_output2 = "data/extracted/opus/{zip_dataset}.{codeA}-{codeB}.{code2}".format(
+            code1=code1, code2=code2, codeA=codeA, codeB=codeB, zip_dataset=zip_dataset
         )
         output1, output2 = output
         shell("unzip -o -d 'data/extracted/opus/' {input} && mv {zip_output1} {output1} && mv {zip_output2} {output2} && touch {output}")

--- a/Snakefile
+++ b/Snakefile
@@ -572,13 +572,13 @@ rule download_paracrawl:
         else:
             raise ValueError("One language in a ParaCrawl pair must be English")
 
-        shell("curl -lf 'https://s3.amazonaws.com/web-language-models/paracrawl/release1.2/paracrawl-release1.2.en-{otherlang}.withstats.filtered-bicleaner.tmx.gz' -o {output}")
+        shell("curl -Lf 'https://s3.amazonaws.com/web-language-models/paracrawl/release1.2/paracrawl-release1.2.en-{otherlang}.withstats.filtered-bicleaner.tmx.gz' -o {output}")
 
 rule download_jesc:
     output:
         "data/downloaded/jesc/detokenized.tar.gz"
     run:
-        "curl -lf 'http://nlp.stanford.edu/rpryzant/jesc/detokenized.tar.gz' -o {output}"
+        "curl -Lf 'http://nlp.stanford.edu/rpryzant/jesc/detokenized.tar.gz' -o {output}"
 
 
 # Handling downloaded data


### PR DESCRIPTION
As far as I can tell, OPUS seems to have silently changed their OpenSubtitles zip files. The files are named "OpenSubtitles2018", but when you extract their _contents_, those files are now named "OpenSubtitles" instead of "OpenSubtitles2018".

I added some logic to the Snakefile to account for this case. I hope this is the only discrepancy.