### PR TITLE
Add test set

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -275,6 +275,13 @@ PARALLEL_LANGUAGE_PAIRS = [
     'en_ru', 'en_sv', 'en_zh-Hans', 'en_zh-Hant'
 ]
 
+# Tatoeba language pairs; constructed manually
+# cs_en, en_lv, en_ro, and en_zh-Hant are removed from PARALLEL_LANGUAGE_PAIRS
+TATOEBA_LANGUAGE_PAIRS = [
+    'ar_en', 'de_en', 'en_es', 'en_fa', 'en_fi', 'en_fr', 'en_it',
+    'en_ja', 'en_nl', 'en_pl', 'en_pt','en_ru', 'en_sv', 'en_zh-Hans'
+]
+
 # We want some flexibility in the amount of data we encode via SentencePiece
 # to use in training a language model.  That data will be a subset of the
 # monolingual data sampled to train SentencePiece itself; we define the size
@@ -447,7 +454,7 @@ rule wordfreq:
 rule parallel:
     input:
         expand("data/parallel/training/{pair}.{mode}.txt", pair=PARALLEL_LANGUAGE_PAIRS, mode=['train', 'valid', 'test']),
-        expand("data/parallel/training/tatoeba_test.{pair}.txt", pair=PARALLEL_LANGUAGE_PAIRS)
+        expand("data/parallel/training/tatoeba_test.{pair}.txt", pair=TATOEBA_LANGUAGE_PAIRS)
 
 rule frequencies:
     input:
@@ -1216,8 +1223,8 @@ rule split_train_valid_test:
     run:
         train_file, valid_file, test_file = output
         shell(
-            "sed -n '1,10000p' ${input} > ${test_file} && "
-            "sed -n '10001,20000p' ${input} > ${valid_file} &&"
+            "sed -n '1,10000p' {input} > {test_file} && "
+            "sed -n '10001,20000p' {input} > {valid_file} && "
             "tail -n +20001 {input} > {train_file}"
         )
 

--- a/Snakefile
+++ b/Snakefile
@@ -275,8 +275,8 @@ PARALLEL_LANGUAGE_PAIRS = [
     'en_ru', 'en_sv', 'en_zh-Hans', 'en_zh-Hant'
 ]
 
-# Tatoeba language pairs; constructed manually
-# cs_en, en_lv, en_ro, and en_zh-Hant are removed from PARALLEL_LANGUAGE_PAIRS
+# Tatoeba language pairs; constructed manually such that cs_en, en_lv, en_ro, and
+# en_zh-Hant are removed from PARALLEL_LANGUAGE_PAIRS
 TATOEBA_LANGUAGE_PAIRS = [
     'ar_en', 'de_en', 'en_es', 'en_fa', 'en_fi', 'en_fr', 'en_it',
     'en_ja', 'en_nl', 'en_pl', 'en_pt','en_ru', 'en_sv', 'en_zh-Hans'
@@ -1094,6 +1094,7 @@ rule separate_parallel:
         shell("cut -f 1 {input} > {out1} && cut -f 2 {input} > {out2}")
 
 
+# BPE is learned only from the train set and is later applied to train, valid, and test sets
 rule learn_bpe:
     input:
         "data/parallel/shuffled-split/{lang1}_{lang2}.{lang1}.train.txt",
@@ -1213,6 +1214,8 @@ rule apply_bpe_tatoeba:
         )
 
 
+# Split files into train, valid, and test sets; 10000 lines for valid and test set each
+# and rest is kept for the train set.
 rule split_train_valid_test:
     input:
         "data/parallel/shuffled-split/{pair}.{lang}.all.txt"

--- a/Snakefile
+++ b/Snakefile
@@ -448,7 +448,7 @@ rule wordfreq:
 
 rule parallel:
     input:
-        expand("data/parallel/training/{pair}.{mode}.txt", pair=PARALLEL_LANGUAGE_PAIRS, mode=['train', 'valid'])
+        expand("data/parallel/training/{pair}.{mode}.txt", pair=PARALLEL_LANGUAGE_PAIRS, mode=['train', 'valid', 'test'])
 
 rule frequencies:
     input:
@@ -1192,17 +1192,19 @@ rule apply_bpe:
         )
 
 
-rule split_train_valid:
+rule split_train_valid_test:
     input:
         "data/parallel/bpe/{pair}.{lang}.all.txt"
     output:
         "data/parallel/bpe/{pair}.{lang}.train.txt",
-        "data/parallel/bpe/{pair}.{lang}.valid.txt"
+        "data/parallel/bpe/{pair}.{lang}.valid.txt",
+        "data/parallel/bpe/{pair}.{lang}.test.txt"
     run:
-        train_file, valid_file = output
+        train_file, valid_file, test_file = output
         shell(
-            "head -n 100000 {input} > {valid_file} && "
-            "tail -n +100001 {input} > {train_file}"
+            "sed -n '1,10000p' ${input} > ${test_file} && "
+            "sed -n '10001,20000p' ${input} > ${valid_file} &&"
+            "tail -n +20001 {input} > {train_file}"
         )
 
 

--- a/Snakefile
+++ b/Snakefile
@@ -584,7 +584,7 @@ rule download_jesc:
     output:
         "data/downloaded/jesc/detokenized.tar.gz"
     shell:
-        "curl -Lf 'http://nlp.stanford.edu/rpryzant/jesc/detokenized.tar.gz' -o {output}"
+        "curl -Lf 'https://nlp.stanford.edu/rpryzant/jesc/detokenized.tar.gz' -o {output}"
 
 
 # Handling downloaded data


### PR DESCRIPTION
Details:
- Tatoeba is used only as a test dataset (and is not used during training or for validation).
- There are two sets of test dataset: one from all sources (just like validation dataset; 10000 lines) and another just from Tatoeba. 
- BPE is learned only from the train set and is later applied to train, valid, and test sets (including Tatoeba).