### PR TITLE
Replace BPE with SentencePiece

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1122,10 +1122,12 @@ rule train_sentencepiece:
     output:
         "data/parallel/training/sp/{pair}.{lang}.model",
         "data/parallel/training/sp/{pair}.{lang}.nmt.vocab"
+    resources:
+        sp_trainer=1
     run:
         model_file, nmt_vocab_file = output
         shell(
-            "xc train-sp {input} {wildcards.pair}.{wildcards.lang} && "
+            "xc train-sp {input} data/parallel/training/sp/{wildcards.pair}.{wildcards.lang} && "
             "xc get-vocab-sp {nmt_vocab_file} {model_file}"
         )
 

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-snakemake $@ -j 8 --resources download=4 --resources opusdownload=1
+snakemake $@ -j 8 --resources download=4 --resources opusdownload=1 --resources sp_trainer=1

--- a/exquisite_corpus/cli.py
+++ b/exquisite_corpus/cli.py
@@ -1,8 +1,12 @@
 import click
-from .tokens import tokenize_file, tokenize_by_language, tokenize_with_sentencepiece
 from .preprocess import preprocess_reddit, preprocess_twitter
 from .sparse_assoc import make_sparse_assoc, intersperse_parallel_text
 from .count import count_tokenized, recount_messy
+from .tokens import (
+    tokenize_file, tokenize_by_language, tokenize_with_sentencepiece,
+    train_sentencepiece, encode_with_sp_as_pieces, decode_pieces_with_sp,
+    get_vocabulary_from_sp
+)
 from .freq import (
     count_files_to_freqs, single_count_file_to_freqs, freqs_to_cBpack,
     freqs_to_jieba
@@ -137,3 +141,33 @@ def run_sparse_assoc(parallel_text_dir, vocab_dir, output_dir, languages, vocab_
 @click.argument('lang2')
 def run_intersperse(input_file, output_file, lang1, lang2):
     intersperse_parallel_text(input_file, output_file, lang1, lang2)
+
+
+@cli.command(name='train-sp')
+@click.argument('input_file')
+@click.argument('model_prefix')
+def run_train_sentencepiece(input_file, model_prefix):
+    train_sentencepiece(input_file, model_prefix)
+
+
+@cli.command(name='encode-with-sp')
+@click.argument('input_file', type=click.File('r', encoding='utf-8', errors='ignore'), default='-')
+@click.argument('output_file', type=click.File('w'), default='-')
+@click.argument('model_file')
+def run_encode_with_sp_as_pieces(input_file, output_file, model_file):
+    encode_with_sp_as_pieces(input_file, output_file, model_file)
+
+
+@cli.command(name='decode-with-sp')
+@click.argument('input_file', type=click.File('r', encoding='utf-8', errors='ignore'), default='-')
+@click.argument('output_file', type=click.File('w'), default='-')
+@click.argument('model_file')
+def run_decode_pieces_with_sp(input_file, output_file, model_file):
+    decode_pieces_with_sp(input_file, output_file, model_file)
+
+
+@cli.command(name='get-vocab-sp')
+@click.argument('output_file', type=click.File('w'), default='-')
+@click.argument('model_file')
+def run_get_vocabulary_from_sp(output_file, model_file):
+    get_vocabulary_from_sp(output_file, model_file)

--- a/exquisite_corpus/cli.py
+++ b/exquisite_corpus/cli.py
@@ -151,23 +151,23 @@ def run_train_sentencepiece(input_file, model_prefix):
 
 
 @cli.command(name='encode-with-sp')
-@click.argument('input_file', type=click.File('r', encoding='utf-8', errors='ignore'), default='-')
-@click.argument('output_file', type=click.File('w'), default='-')
+@click.argument('input_file', type=click.File('r', encoding='utf-8'), default='-')
+@click.argument('output_file', type=click.File('w', encoding='utf-8'), default='-')
 @click.argument('model_file')
 def run_encode_with_sp_as_pieces(input_file, output_file, model_file):
     encode_with_sp_as_pieces(input_file, output_file, model_file)
 
 
 @cli.command(name='decode-with-sp')
-@click.argument('input_file', type=click.File('r', encoding='utf-8', errors='ignore'), default='-')
-@click.argument('output_file', type=click.File('w'), default='-')
+@click.argument('input_file', type=click.File('r', encoding='utf-8'), default='-')
+@click.argument('output_file', type=click.File('w', encoding='utf-8'), default='-')
 @click.argument('model_file')
 def run_decode_pieces_with_sp(input_file, output_file, model_file):
     decode_pieces_with_sp(input_file, output_file, model_file)
 
 
 @cli.command(name='get-vocab-sp')
-@click.argument('output_file', type=click.File('w'), default='-')
+@click.argument('output_file', type=click.File('w', encoding='utf-8'), default='-')
 @click.argument('model_file')
 def run_get_vocabulary_from_sp(output_file, model_file):
     get_vocabulary_from_sp(output_file, model_file)

--- a/exquisite_corpus/tokens.py
+++ b/exquisite_corpus/tokens.py
@@ -78,7 +78,8 @@ def tokenize_with_sentencepiece(in_file, out_file, sp_model_filename):
 
 
 def train_sentencepiece(in_file, model_prefix):
-    parms = "--input={} --model_prefix={} --vocab_size=8000 --hard_vocab_limit=false".format(in_file, model_prefix)
+    parms = "--input={} --model_prefix={} --vocab_size=16000 --hard_vocab_limit=false " \
+            "--input_sentence_size=1000000 --shuffle_input_sentence".format(in_file, model_prefix)
     sentencepiece.SentencePieceTrainer.Train(parms)
 
 

--- a/exquisite_corpus/tokens.py
+++ b/exquisite_corpus/tokens.py
@@ -83,7 +83,8 @@ def train_sentencepiece(in_file, model_prefix):
     Outputs are model and vocabulary files (<prefix>.model and <prefix>.vocab).
     Maximum size of sentences the trainer loads, by randomly sampling input sentences,
     is 1M. Vocabulary size is 16K and is a soft limit.
-    It uses NFKC normalization with some additional normalization around spaces.
+    It uses NFKC normalization with some additional normalization around spaces and
+    Unicode case folding (mostly lower casing).
     """
     parms = "--model_type=unigram " \
             "--input={file} " \
@@ -93,7 +94,7 @@ def train_sentencepiece(in_file, model_prefix):
             "--shuffle_input_sentence " \
             "--vocab_size=16000 " \
             "--hard_vocab_limit=false " \
-            "--normalization_rule_name=nmt_nfkc".format(file=in_file, prefix=model_prefix)
+            "--normalization_rule_name=nmt_nfkc_cf".format(file=in_file, prefix=model_prefix)
     sentencepiece.SentencePieceTrainer.Train(parms)
 
 

--- a/exquisite_corpus/tokens.py
+++ b/exquisite_corpus/tokens.py
@@ -75,3 +75,34 @@ def tokenize_with_sentencepiece(in_file, out_file, sp_model_filename):
     for line in in_file:
         ids = sp.encode_as_ids(line.rstrip())
         out_file.write(packer.pack(ids))
+
+
+def train_sentencepiece(in_file, model_prefix):
+    parms = "--input={} --model_prefix={} --vocab_size=8000 --hard_vocab_limit=false".format(in_file, model_prefix)
+    sentencepiece.SentencePieceTrainer.Train(parms)
+
+
+def encode_with_sp_as_pieces(in_file, out_file, model_file):
+    spp = sentencepiece.SentencePieceProcessor()
+    spp.load(model_file)
+    for line in in_file:
+        pieces = spp.encode_as_pieces(line.rstrip())
+        line_pieces = ' '.join(pieces) + '\n'
+        out_file.write(line_pieces)
+
+
+def decode_pieces_with_sp(in_file, out_file, model_file):
+    spp = sentencepiece.SentencePieceProcessor()
+    spp.load(model_file)
+    for line in in_file:
+        line_pieces = spp.decode_pieces(line.split()) + '\n'
+        out_file.write(line_pieces)
+
+
+def get_vocabulary_from_sp(out_file, model_file):
+    spp = sentencepiece.SentencePieceProcessor()
+    spp.load(model_file)
+    # <unk>, <s>, </s> are defined by default. Their ids are (0, 1, 2)
+    for id in range(3, spp.get_piece_size()):
+        pieces = spp.id_to_piece(id) + '\n'
+        out_file.write(pieces)


### PR DESCRIPTION
This PR contains the following changes:
- BPE is replaced with SentencePiece Unigram model.
- SentencepPiece is applied to raw data (without pre-tokenization) for all languages.
- Everything needed for training NMT is in /parallel/training; /sp contains SentencePiece model and vocabulary, /paired contains monolingual language pairs and /joined contains these language pairs joined into a single file (languages are separated by TABs).