### PR TITLE
Small fix to rule join_training_data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1239,7 +1239,7 @@ rule split_train_valid_test:
 
 rule join_training_data:
     input:
-        DATA + "data/parallel/training/paired/{lang1}_{lang2}.{lang1}.{" \
+        DATA + "/parallel/training/paired/{lang1}_{lang2}.{lang1}.{" \
              "mode}.txt",
         DATA + "/parallel/training/paired/{lang1}_{lang2}.{lang2}.{mode}.txt"
     output:


### PR DESCRIPTION
This PR fixes rule join_training_data to make parallel corpus build to succeed. 