### PR TITLE
Switch language identification from fastText to lumi-language-id for parallel corpus cleanup.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1131,10 +1131,8 @@ rule cleanup_parallel:
         DATA + "/parallel/shuffled/{lang1}_{lang2}.txt"
     output:
         DATA + "/parallel/shuffled-clean/{lang1}_{lang2}.txt"
-    run:
-        shell(
-            "xc cleanup-parallel {input} {output} {wildcards.lang1} {wildcards.lang2}"
-        )
+    shell:
+        "xc cleanup-parallel {input} {output} {wildcards.lang1} {wildcards.lang2}"
 
 
 rule separate_parallel:

--- a/Snakefile
+++ b/Snakefile
@@ -1126,24 +1126,14 @@ rule shuffle_parallel:
         "cat {input} | scripts/imperfect-shuffle.sh {output} parallel_{wildcards.lang1}_{wildcards.lang2}"
 
 
-rule download_fasttext_lid:
-    output:
-        DATA + "/parallel/fasttext-lid/lid.176.bin"
-    shell:
-        "curl -Lf 'https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin' -o {output}"
-
-
 rule cleanup_parallel:
     input:
-        DATA + "/parallel/shuffled/{lang1}_{lang2}.txt",
-        DATA + "/parallel/fasttext-lid/lid.176.bin"
+        DATA + "/parallel/shuffled/{lang1}_{lang2}.txt"
     output:
         DATA + "/parallel/shuffled-clean/{lang1}_{lang2}.txt"
     run:
-        input_file, fasttext_model_file = input
         shell(
-            "xc cleanup-parallel {input_file} {output} {fasttext_model_file} "
-            "{wildcards.lang1} {wildcards.lang2}"
+            "xc cleanup-parallel {input} {output} {wildcards.lang1} {wildcards.lang2}"
         )
 
 

--- a/exquisite_corpus/cli.py
+++ b/exquisite_corpus/cli.py
@@ -152,7 +152,6 @@ def run_intersperse(input_file, output_file, lang1, lang2):
 @cli.command(name='cleanup-parallel')
 @click.argument('input_file', type=click.File('r', encoding='utf-8'), default='-')
 @click.argument('output_file', type=click.File('w', encoding='utf-8'), default='-')
-@click.argument('ft_model_file')
 @click.argument('lang1')
 @click.argument('lang2')
 def run_cleanup_parallel_file(input_file, output_file, lang1, lang2):

--- a/exquisite_corpus/cli.py
+++ b/exquisite_corpus/cli.py
@@ -155,8 +155,8 @@ def run_intersperse(input_file, output_file, lang1, lang2):
 @click.argument('ft_model_file')
 @click.argument('lang1')
 @click.argument('lang2')
-def run_cleanup_parallel_file(input_file, output_file, ft_model_file, lang1, lang2):
-    cleanup_parallel_file(input_file, output_file, ft_model_file, lang1, lang2)
+def run_cleanup_parallel_file(input_file, output_file, lang1, lang2):
+    cleanup_parallel_file(input_file, output_file, lang1, lang2)
 
 
 @cli.command(name='train-sp')

--- a/exquisite_corpus/parallel_corpus.py
+++ b/exquisite_corpus/parallel_corpus.py
@@ -51,11 +51,11 @@ def cleanup_parallel_file(
         # sides consist of the right language.
         lang1_pred, _lang1_confidence = detect_language(lang1_sent)
         lang1 = map_to_fasttext_language(lang1)
-        clean_lang1 = lang1_pred == lang1
+        lang1_match = lang1_pred == lang1
 
         lang2_pred, _lang2_confidence = detect_language(lang2_sent)
         lang2 = map_to_fasttext_language(lang2)
-        clean_lang2 = lang2_pred == lang2
+        lang2_match = lang2_pred == lang2
 
         # Require the source and target length ratio to not exceed 4.0. This also makes
         # sure that there are no empty source or target side so that fast_align would
@@ -75,7 +75,7 @@ def cleanup_parallel_file(
         # in the source or target side.
         no_tab = '\t' not in lang1_sent and '\t' not in lang2_sent
 
-        if note_match and clean_lang1 and clean_lang2 and balanced and no_tab:
+        if note_match and lang1_match and lang2_match and balanced and no_tab:
             outfile.write(line + '\n')
 
 

--- a/exquisite_corpus/parallel_corpus.py
+++ b/exquisite_corpus/parallel_corpus.py
@@ -1,7 +1,4 @@
-import string
-import unicodedata
-
-import fasttext
+from lumi_language_id import detect_language
 import sentencepiece
 
 from ftfy import fix_text
@@ -9,7 +6,7 @@ from ftfy import fix_text
 
 def map_to_fasttext_language(lang):
     """
-    Map both 'zh-Hans' and 'zh-Hant' to 'zh' for fastText language identification.
+    Map both 'zh-Hans' and 'zh-Hant' to 'zh' for language identification.
     """
     mapping = {
         'zh-Hans': 'zh',
@@ -18,63 +15,14 @@ def map_to_fasttext_language(lang):
     return mapping.get(lang, lang)
 
 
-def clean_text_for_ft(text):
-    """
-    Prediction of FastText's language identification model improves when the input text
-    is clean; so, we clean it before passing it to the model for prediction.
-    """
-    # FastText's predict() processes one line at a time; so remove '\n'
-    cleaned_text = text.replace('\n', ' ')
-
-    # Normalize with NFKC and lower case the text
-    cleaned_text = unicodedata.normalize('NFKC', cleaned_text).lower()
-
-    # Remove punctuations and digits
-    excluded = set(string.punctuation)
-    cleaned_text = ''.join(
-        ch for ch in cleaned_text if
-        ch.isprintable() and not ch.isdigit() and ch not in excluded
-    )
-
-    # Remove extra whitespaces
-    cleaned_text = ' '.join(cleaned_text.split())
-
-    return cleaned_text
-
-
-def get_ft_lang_code_prob(text, fasttext_model):
-    """
-    Get the language code and the corresponding probability of a text using FastText's
-    language identification model.
-    """
-    assert isinstance(text, str), \
-        'The text has to be a string.'
-
-    text = clean_text_for_ft(text)
-
-    # Given a text, get a label and corresponding probability. By default, predict()
-    # returns only one label- the one with the highest probability.
-    # Example output of predict():
-    # (('__label__en',), array([0.98069412]))
-    len_label = len('__label__')
-    lang_pred = fasttext_model.predict(text.lower())
-    lang_pred_code = lang_pred[0][0][len_label:]
-    lang_pred_prob = lang_pred[1][0]
-
-    return lang_pred_code, lang_pred_prob
-
-
 def cleanup_parallel_file(
-        infile, outfile, fasttext_model_file, lang1, lang2
+        infile, outfile, lang1, lang2
 ):
     """
     Take in a tab-separated parallel text, run ftfy over each line, and skip the line if
     the text on either side contains different numbers of '♪' or if languages on either
     side are not identified with confidence (given text is long enough).
     """
-    # Load the FastText's language identification model
-    fasttext_model = fasttext.load_model(fasttext_model_file)
-
     for line in infile:
         # Run all ftfy fixes
         line = fix_text(line)
@@ -101,34 +49,19 @@ def cleanup_parallel_file(
         # There can be mixed or wrong language in source and/or target; including
         # untranslated source in the target. So, make sure that the sentences on both
         # sides consist of the right language.
-        clean_lang1 = True
-        clean_lang2 = True
+        lang1_pred, _lang1_confidence = detect_language(lang1_sent)
+        lang1 = map_to_fasttext_language(lang1)
+        clean_lang1 = lang1_pred == lang1
 
-        # Minimum length to perform language identification
-        min_length = 25
-
-        # Threshold to say that the language has been identified with confidence
-        id_threshold = 0.70
-
-        len_lang1_sent = len(lang1_sent)
-        len_lang2_sent = len(lang2_sent)
-        if len_lang1_sent > min_length:
-            lang1_pred_code, lang1_pred_prob = get_ft_lang_code_prob(
-                lang1_sent, fasttext_model
-            )
-            lang1 = map_to_fasttext_language(lang1)
-            clean_lang1 = lang1_pred_code == lang1 and lang1_pred_prob >= id_threshold
-
-        if len_lang2_sent > min_length:
-            lang2_pred_code, lang2_pred_prob = get_ft_lang_code_prob(
-                lang2_sent, fasttext_model
-            )
-            lang2 = map_to_fasttext_language(lang2)
-            clean_lang2 = lang2_pred_code == lang2 and lang2_pred_prob >= id_threshold
+        lang2_pred, _lang2_confidence = detect_language(lang2_sent)
+        lang2 = map_to_fasttext_language(lang2)
+        clean_lang2 = lang2_pred == lang2
 
         # Require the source and target length ratio to not exceed 4.0. This also makes
         # sure that there are no empty source or target side so that fast_align would
         # not throw an error.
+        len_lang1_sent = len(lang1_sent)
+        len_lang2_sent = len(lang2_sent)
         ratio = 0.0
         if len_lang2_sent != 0:
             ratio = len_lang1_sent / len_lang2_sent

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     install_requires=[
         'snakemake < 5.6', 'wordfreq[jieba,mecab] >= 2.3.2', 'click',
         'regex >= 2018.01.08', 'pycld2', 'msgpack-python', 'ordered-set',
-        'ftfy', 'subword-nmt', 'sentencepiece', 'mmh3', 'pytest', 'tqdm', 'fasttext'
+        'ftfy', 'subword-nmt', 'sentencepiece', 'mmh3', 'pytest', 'tqdm',
+        'lumi-language-id'
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/test_parallel_corpus.py
+++ b/tests/test_parallel_corpus.py
@@ -7,9 +7,8 @@ import sentencepiece
 import fasttext
 
 from exquisite_corpus.parallel_corpus import (
-    clean_text_for_ft, cleanup_parallel_file, decode_pieces_with_sp,
-    encode_with_sp_as_pieces, get_ft_lang_code_prob, get_vocabulary_from_sp,
-    train_sentencepiece
+    cleanup_parallel_file, decode_pieces_with_sp, encode_with_sp_as_pieces,
+    get_vocabulary_from_sp, train_sentencepiece
 )
 
 THIS_DIR = os.path.dirname(__file__)
@@ -22,71 +21,6 @@ ENCODED = [
     '▁ a b c d e f g h i j k l m n o p q r s t u v w x y z',
     '▁ t h i s ▁ i s ▁ a ▁ s a m p l e ▁ t e x t'
 ]
-
-
-@pytest.fixture(scope="session")
-def path_to_ft_model():
-    # Download FastText model only if needed
-    fasttext_model_dir = os.path.join(THIS_DIR, 'ft_model')
-    fasttext_model_path = os.path.join(fasttext_model_dir, 'lid.176.bin')
-    if not os.path.isfile(fasttext_model_path):
-        if not os.path.exists(fasttext_model_dir):
-            os.makedirs(fasttext_model_dir)
-        subprocess.call(
-            [
-                'curl', '-Lf',
-                'https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin',
-                '-o', fasttext_model_path
-            ]
-        )
-    return fasttext_model_path
-
-
-def test_clean_text_for_ft():
-    """
-    Test if the text is cleaned as expected.
-    """
-    # Check if '\n' is removed
-    text = 'This is a sample text with new line character.\n'
-    text = clean_text_for_ft(text)
-    assert '\n' not in text
-
-    # Check if all the characters are lower case
-    text = 'This is a sample text with Upper Case.'
-    text = clean_text_for_ft(text)
-    assert text.islower()
-
-    # Check if punctuations and digits are removed
-    text = 'This is 1 and only 1 text with punctuations and digits!!'
-    text = clean_text_for_ft(text)
-    assert '1' not in text and '!' not in text
-
-
-def test_get_ft_lang_code_prob(path_to_ft_model):
-    """
-    Test if the language code and the corresponding probability of texts are as
-    expected.
-    """
-    # Load the FastText's language identification model
-    fasttext_model = fasttext.load_model(path_to_ft_model)
-
-    # Check if an expected exception is raised for a non-string
-    with pytest.raises(AssertionError):
-        text = []
-        _, _ = get_ft_lang_code_prob(text, fasttext_model)
-
-    # FT's predict() exptects one line at a time. Test if '\n' is removed before
-    # the prediction
-    try:
-        text = 'This test is in English.\n It contains newline character.'
-        _, _ = get_ft_lang_code_prob(text, fasttext_model)
-    except ValueError as err:
-        pytest.fail(repr(err))
-
-    # This should be identified with low probability
-    text = ''
-    _, lang_pred_prob = get_ft_lang_code_prob(text, fasttext_model)
-    assert lang_pred_prob < 0.15
 
 
 @pytest.mark.parametrize(
@@ -162,12 +96,12 @@ def test_get_ft_lang_code_prob(path_to_ft_model):
 
     ]
 )
-def test_cleanup_parallel_file(text, expected, lang1, lang2, path_to_ft_model):
+def test_cleanup_parallel_file(text, expected, lang1, lang2):
     in_file = [text]
     out_file = StringIO()
 
     cleanup_parallel_file(
-        in_file, out_file, path_to_ft_model, lang1, lang2
+        in_file, out_file, lang1, lang2
     )
     out_file.seek(0)
     assert out_file.read() == expected


### PR DESCRIPTION
This PR switches language identification from fastText to lumi-language-id for parallel corpus cleanup.
