### PR TITLE
Add data extra requirement to langcodes requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'snakemake < 5.6', 'jieba >= 0.42', 'wordfreq[jieba,mecab] >= 2.3.2',
         'click', 'regex >= 2020.04.04', 'pycld2', 'msgpack-python',
         'ordered-set', 'ftfy', 'subword-nmt', 'sentencepiece==0.1.86', 'mmh3',
-        'pytest', 'tqdm', 'lumi-language-id', 'zstandard', 'langcodes >= 2.1',
+        'pytest', 'tqdm', 'lumi-language-id', 'zstandard', 'langcodes[data] >= 2.1',
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
This seems to be required now, otherwise I get the following:

```
Looking up language names now requires the `language_data` package.

Install it with:
    pip install language_data
Or as an optional feature of langcodes:
    pip install langcodes[data]
```
